### PR TITLE
Support only to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-   - 7.0
+   - 7.1
 
 install:
    - composer install

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Total Downloads](https://poser.pugx.org/bauhaus/container/downloads?format=flat-square)](https://packagist.org/packages/bauhaus/container)
 [![License](https://poser.pugx.org/bauhaus/container/license?format=flat-square)](LICENSE)
 
-[![Build Status](https://img.shields.io/travis/bauhausphp/package-container/master.svg?style=flat-square)](https://travis-ci.org/bauhausphp/package-container)
-[![Coverage Status](https://img.shields.io/coveralls/bauhausphp/package-container/master.svg?style=flat-square)](https://coveralls.io/github/bauhausphp/package-container?branch=master)
-[![Codacy Badge](https://img.shields.io/codacy/9e4bf1d8a6e649b1b48c5a2251d1c78e.svg?style=flat-square)](https://www.codacy.com/app/fefas/bauhausphp-package-container)
+[![Build Status](https://img.shields.io/travis/bauhausphp/container/master.svg?style=flat-square)](https://travis-ci.org/bauhausphp/container)
+[![Coverage Status](https://img.shields.io/coveralls/bauhausphp/container/master.svg?style=flat-square)](https://coveralls.io/github/bauhausphp/container?branch=master)
+[![Codacy Badge](https://img.shields.io/codacy/9e4bf1d8a6e649b1b48c5a2251d1c78e.svg?style=flat-square)](https://www.codacy.com/app/fefas/bauhausphp-container)
 
 ## Introduction
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
 
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "container-interop/container-interop": "^1.1"
   },
 

--- a/src/ContainerItemException.php
+++ b/src/ContainerItemException.php
@@ -6,7 +6,7 @@ use Interop\Container\Exception\ContainerException;
 
 abstract class ContainerItemException extends \Exception implements ContainerException
 {
-    public function __construct($label)
+    public function __construct(string $label)
     {
         parent::__construct(sprintf($this->messageTemplate(), $label));
     }

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -8,10 +8,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->container = new Container($this->readableContainerItems());
+        $this->container = new Container($this->containerItems());
     }
 
-    protected function readableContainerItems()
+    protected function containerItems()
     {
         return [
             'pokemon' => 'Charmander',
@@ -42,7 +42,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function labelsAndTheirExistence()
     {
-        foreach (array_keys($this->readableContainerItems()) as $label) {
+        foreach (array_keys($this->containerItems()) as $label) {
             yield [$label, true];
         }
 
@@ -55,7 +55,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @dataProvider labelsAndValuesOfItems
      */
-    public function retrieveTheValueOfAnItemByItsLabel($label, $expectedValue)
+    public function retrieveValueOfAnItemByItsLabel($label, $expectedValue)
     {
         $this->assertEquals($expectedValue, $this->container->get($label));
     }
@@ -64,14 +64,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @dataProvider labelsAndValuesOfItems
      */
-    public function retrieveTheValueOfAnItemByItsLabelUsingMagicMethod($label, $expectedValue)
+    public function retrieveValueOfAnItemByItsLabelUsingMagicMethod($label, $expectedValue)
     {
         $this->assertEquals($expectedValue, $this->container->$label);
     }
 
     public function labelsAndValuesOfItems()
     {
-        foreach ($this->readableContainerItems() as $label => $value) {
+        foreach ($this->containerItems() as $label => $value) {
             yield [$label, $value];
         }
     }
@@ -81,7 +81,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function retrieveAllItemsWhenCallingTheMethodAll()
     {
-        $expectedItems = $this->readableContainerItems();
+        $expectedItems = $this->containerItems();
 
         $this->assertEquals($expectedItems, $this->container->all());
     }
@@ -96,7 +96,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             $outcome[$label] = $value;
         }
 
-        $this->assertEquals($this->readableContainerItems(), $outcome);
+        $this->assertEquals($this->containerItems(), $outcome);
     }
 
     /**


### PR DESCRIPTION
My intension is only to give full support to the last PHP stable version. It may force the developers always to keep their application updated and they will need tests to have no fear about upgrading PHP.