### PR TITLE
Method asArray throws Exception

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -37,8 +37,8 @@ class Container implements ContainerInterface
         return $this->items;
     }
 
-    public function toArray(): array
+    public function asArray(): array
     {
-        return $this->items();
+        throw new \RuntimeException('Method asArray not implemented');
     }
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -10,5 +10,5 @@ interface ContainerInterface extends IteropContainerInterface
     public function get($label);
     public function __get($label);
     public function items(): array;
-    public function toArray(): array;
+    public function asArray(): array;
 }

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -88,12 +88,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Method asArray not implemented
      */
     public function canBeConvertedToArray()
     {
-        $expectedItems = $this->containerItems();
-
-        $this->assertEquals($expectedItems, $this->container->toArray());
+        $this->container->asArray();
     }
 
     /**


### PR DESCRIPTION
As the class container does not know the properties of the items to be stored,
it is not its responsibility to convert them to an array.